### PR TITLE
Differentiate between left and right labels in custom label formatter

### DIFF
--- a/jQDateRangeSlider.js
+++ b/jQDateRangeSlider.js
@@ -79,8 +79,8 @@
 			}
 
 			return (function(formatter){
-				return function(value){
-					return formatter(new Date(value));
+				return function(value, isLeft){
+					return formatter(new Date(value), isLeft);
 				};
 			}(formatter));
 		},

--- a/jQRangeSliderLabel.js
+++ b/jQRangeSliderLabel.js
@@ -128,7 +128,7 @@
 			if (this.options.formatter === false){
 				this._displayText(Math.round(value));
 			}else{
-				this._displayText(this.options.formatter(value));
+				this._displayText(this.options.formatter(value, this.options.isLeft));
 			}
 
 			this._value = value;


### PR DESCRIPTION
Enable left and right labels to be formatted differently. E.g. problem: if selecting a month range, the left and right labels are 1 July 2019 to 1 August 2019, but 1 August is not included in the range. Solution: decrement the right value in the custom formatter before generating its label.